### PR TITLE
security: HTTP security headers + remove x-powered-by

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,10 +1,27 @@
 /** @type {import('next').NextConfig} */
+
+// Security headers applied to every route.
+// CSP is intentionally added separately (Report-Only first, then enforced)
+// once per-page script/style/img sources are enumerated, to avoid breakage.
+const securityHeaders = [
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()' },
+  { key: 'X-DNS-Prefetch-Control', value: 'on' },
+];
+
 const nextConfig = {
   reactStrictMode: true,
+  poweredByHeader: false,
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: 'res.cloudinary.com', pathname: '/dygcwhekh/**' },
     ],
+  },
+  async headers() {
+    return [{ source: '/:path*', headers: securityHeaders }];
   },
 };
 


### PR DESCRIPTION
Closes the biggest app-layer gap from the security audit: the site currently sends **no** security headers.

**Adds (all routes):**
- `Strict-Transport-Security` (HSTS, 2y, includeSubDomains, preload)
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: SAMEORIGIN` (clickjacking)
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy` (camera/mic/geo/topics denied)
- `X-DNS-Prefetch-Control: on`
- `poweredByHeader: false` — removes `x-powered-by: Next.js` stack disclosure

**Deferred on purpose:** Content-Security-Policy — rolled out next as Report-Only, then enforced, once per-page script/style/img sources are mapped (a blind CSP white-screens the site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)